### PR TITLE
Updates OrackeJDK to version 1.8.0u112

### DIFF
--- a/Formula/jdk.rb
+++ b/Formula/jdk.rb
@@ -8,11 +8,11 @@ class Jdk < Formula
   homepage "http://www.oracle.com/technetwork/java/javase/downloads/index.html"
   # tag "linuxbrew"
 
-  version "1.8.0-102"
+  version "1.8.0-112"
   if OS.linux?
-    url "http://download.oracle.com/otn-pub/java/jdk/8u102-b14/jdk-8u102-linux-x64.tar.gz",
+    url "http://download.oracle.com/otn-pub/java/jdk/8u112-b15/jdk-8u112-linux-x64.tar.gz",
       :using => JdkDownloadStrategy
-    sha256 "7cfbe0bc0391a4abe60b3e9eb2a541d2315b99b9cb3a24980e618a89229e04b7"
+    sha256 "777bd7d5268408a5a94f5e366c2e43e720c6ce4fe8c59d9a71e2961e50d774a5"
   elsif OS.mac?
     url "http://java.com/"
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

This PR updates to the latest version of the Oracle JDK : 1.8.0u112

Release notes : http://www.oracle.com/technetwork/java/javase/8u112-relnotes-3124973.html
Checksums : https://www.oracle.com/webfolder/s/digest/8u112checksum.html

---

This formula has some previous issues that are not fixed by this PR : 

Currrent (1.8.0-102) : 

```
➜  Formula git:(master) ✗ brew audit --strict jdk
jdk:
  * Formula should have a desc (Description).
  * A top-level "man" directory was found
    Homebrew requires that man pages live under share.
    This can often be fixed by passing "--mandir=#{man}" to configure.
  * JARs were installed to "/home/api-team/.linuxbrew/Cellar/jdk/1.8.0-102/lib"
    Installing JARs to "lib" can cause conflicts between packages.
    For Java software, it is typically better for the formula to
    install to "libexec" and then symlink or wrap binaries into "bin".
    See "activemq", "jruby", etc. for examples.
    The offending files are:
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-102/lib/ant-javafx.jar
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-102/lib/dt.jar
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-102/lib/tools.jar
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-102/lib/javafx-mx.jar
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-102/lib/jconsole.jar
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-102/lib/packager.jar
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-102/lib/sa-jdi.jar
  * Non-libraries were installed to "/home/api-team/.linuxbrew/Cellar/jdk/1.8.0-102/lib"
    Installing non-libraries to "lib" is discouraged.
    The offending files are:
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-102/lib/orb.idl
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-102/lib/ir.idl
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-102/lib/jexec
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-102/lib/ct.sym
  * Non-executables were installed to "/home/api-team/.linuxbrew/Cellar/jdk/1.8.0-102/bin"
    The offending files are:
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-102/bin/jmc.ini
Error: 5 problems in 1 formula
```

PR version (1.8.0-112)

```
jdk:
  * Formula should have a desc (Description).
  * A top-level "man" directory was found
    Homebrew requires that man pages live under share.
    This can often be fixed by passing "--mandir=#{man}" to configure.
  * JARs were installed to "/home/api-team/.linuxbrew/Cellar/jdk/1.8.0-112/lib"
    Installing JARs to "lib" can cause conflicts between packages.
    For Java software, it is typically better for the formula to
    install to "libexec" and then symlink or wrap binaries into "bin".
    See "activemq", "jruby", etc. for examples.
    The offending files are:
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-112/lib/ant-javafx.jar
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-112/lib/dt.jar
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-112/lib/tools.jar
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-112/lib/javafx-mx.jar
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-112/lib/jconsole.jar
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-112/lib/packager.jar
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-112/lib/sa-jdi.jar
  * Non-libraries were installed to "/home/api-team/.linuxbrew/Cellar/jdk/1.8.0-112/lib"
    Installing non-libraries to "lib" is discouraged.
    The offending files are:
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-112/lib/orb.idl
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-112/lib/ir.idl
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-112/lib/jexec
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-112/lib/ct.sym
  * Non-executables were installed to "/home/api-team/.linuxbrew/Cellar/jdk/1.8.0-112/bin"
    The offending files are:
      /home/api-team/.linuxbrew/Cellar/jdk/1.8.0-112/bin/jmc.ini
Error: 5 problems in 1 formula
```
